### PR TITLE
Cover: Validate connection if no updated data is sent

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 import hashlib
 import logging
 import secrets
@@ -150,6 +151,7 @@ class TuyaBLEDataPoints:
         self._datapoints: dict[int, TuyaBLEDataPoint] = {}
         self._update_started: int = 0
         self._updated_datapoints: list[int] = []
+        self._last_data_received: datetime | None = None
 
     def __len__(self) -> int:
         return len(self._datapoints)
@@ -159,6 +161,10 @@ class TuyaBLEDataPoints:
 
     def __dict__(self) -> dict:
         return self._datapoints
+
+    @property
+    def last_data_received(self) -> datetime | None:
+        return self._last_data_received
 
     def has_id(self, id: int, type: TuyaBLEDataPointType | None = None) -> bool:
         return (id in self._datapoints) and (
@@ -196,6 +202,7 @@ class TuyaBLEDataPoints:
         type: TuyaBLEDataPointType,
         value: bytes | bool | int | str,
     ) -> None:
+        self._last_data_received = datetime.now(timezone.utc)
         dp = self._datapoints.get(dp_id)
         if dp:
             dp._update_from_device(timestamp, flags, type, value)
@@ -436,6 +443,10 @@ class TuyaBLEDevice:
                 printable_value = value
             item[key] = printable_value
         return item
+
+    @property
+    def last_data_received(self) -> datetime | None:
+        return self._datapoints.last_data_received
 
     def get_or_create_datapoint(
         self,


### PR DESCRIPTION
After debugging the behavior with the curtain robot more I saw a case where the curtain robot does do nothing even when sending new commands. This is resolved when asking manually for a datapoint update from the robot via BLE.

Thus this change adds a task to verify that the command has triggered a data point update. If no data update has been done the device is in a limbo state and does not do anything. It resets successfully if an update call is executed then which is happening in the task after a second of waiting if no new data has been received.